### PR TITLE
Add support for delete by value

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ go get -u github.com/evanphx/json-patch/v5
   functionality can be disabled by setting `jsonpatch.SupportNegativeIndices =
   false`.
 
+* There is a global configuration variable `jsonpatch.SupportDeleteByValue`.
+  This defaults to `true` and enables the support for the non-standard
+  practice of deleting from an array with value. This functionality
+  can be disabled by setting `jsonpatch.SupportNegativeIndices = false`.
+  This can be used by using `-` instead of the array index and specifying the
+  value to remove in "value". For example:
+  `[{ "op": "remove", "path": "/foo/-", "value": "qux"}]` will delete
+  value `qux` from the array `foo`. This works also with values that are objects.
+
+* There is a global configuration variable `jsonpatch.SupportDeleteObjectByPartialValue`.
+  This defaults to `true` and enables the support for the non-standard
+  practice of deleting from an array with value when the value only specifies partial 
+  document. This functionality can be disabled by setting `jsonpatch.SupportDeleteObjectByPartialValue = false`.
+  This can be used by using `-` instead of the array index and specifying the
+  value to remove partially in "value". For example: if the target document contains
+  `{ "foo": [ {"1": "3", "4": "5", "5": "6"}, {"2": "1"} ] }`, the request payload of `[{ "op": "remove", "path": "/foo/-", "value": {"1": "3" }]` will delete
+  value `{"1": "3", "4": "5", "5": "6"}` from the array `foo`.  
+
 * There is a global configuration variable `jsonpatch.AccumulatedCopySizeLimit`,
   which limits the total size increase in bytes caused by "copy" operations in a
   patch. It defaults to 0, which means there is no limit.

--- a/patch.go
+++ b/patch.go
@@ -27,6 +27,10 @@ var (
 	// SupportDeleteByValue decides whether to support non-standard practice of
 	// allowing deleting from array with value.
 	SupportDeleteByValue bool = true
+	// SupportDeleteObjectByPartialValue decides whether to support non-standard practice of
+	// allowing deleting from array with value when the value is an object and only partial value
+	// is specified in delete request.
+	SupportDeleteObjectByPartialValue bool = true
 )
 
 var (
@@ -519,16 +523,16 @@ func (d *partialArray) removeByValue(key *lazyNode) error {
 			}
 			return false
 		}
-		if isObject(string(*key.raw)) {
+		if SupportDeleteObjectByPartialValue && isObject(string(*key.raw)) {
 			if !isObject(string(*v.raw)) {
 				return errors.Wrapf(ErrInvalidIndex, "value not found")
 			}
-			keyMap := make(map[string] interface{})
 			valueMap := make(map[string] interface{})
 			err := json.Unmarshal([]byte(*v.raw), &valueMap)
 			if err != nil {
 				return errors.Wrapf(ErrInvalidIndex, "value not found")
 			}
+			keyMap := make(map[string] interface{})
 			err = json.Unmarshal([]byte(*key.raw), &keyMap)
 			if err != nil {
 				return errors.Wrapf(ErrInvalidIndex, "value not found")

--- a/patch_test.go
+++ b/patch_test.go
@@ -91,6 +91,36 @@ var Cases = []Case{
 		`{ "foo": [ "bar", "baz" ] }`,
 	},
 	{
+		`{ "foo": [ "bar", "qux", "baz" ] }`,
+		`[ { "op": "remove", "path": "/foo/-" , "value": "qux" }]`,
+		`{ "foo": [ "bar", "baz" ] }`,
+	},
+	{
+		`{ "foo": [ "3", "2", "1" ] }`,
+		`[ { "op": "remove", "path": "/foo/-" , "value": "1" }]`,
+		`{ "foo": [ "3", "2" ] }`,
+	},
+	{
+		`{ "foo": [ [ "bar", "qux", "baz" ], [ "bar", "baz" ], "1" ] }`,
+		`[ { "op": "remove", "path": "/foo/-" , "value": [ "bar", "baz" ] }]`,
+		`{ "foo": [ [ "bar", "qux", "baz" ], "1" ] }`,
+	},
+	{
+		`{ "foo": [ {"1": "3"}, {"2": "1"} ] }`,
+		`[ { "op": "remove", "path": "/foo/-", "value": { "1": "3"} }]`,
+		`{ "foo": [ {"2": "1"} ] }`,
+	},
+	{
+		`{ "foo": [ {"1": "3", "4": "5"}, {"2": "1"} ] }`,
+		`[ { "op": "remove", "path": "/foo/-", "value": { "1": "3"} }]`,
+		`{ "foo": [ {"2": "1"} ] }`,
+	},
+	{
+		`{ "foo": [ {"1": "3", "4": "5", "5": "6"}, {"2": "1"} ] }`,
+		`[ { "op": "remove", "path": "/foo/-", "value": { "1": "3", "5":"6", "4":"5"} }]`,
+		`{ "foo": [ {"2": "1"} ] }`,
+	},
+	{
 		`{ "baz": "qux", "foo": "bar" }`,
 		`[ { "op": "replace", "path": "/baz", "value": "boo" } ]`,
 		`{ "baz": "boo", "foo": "bar" }`,
@@ -185,6 +215,11 @@ var Cases = []Case{
 		`{ "foo": ["bar"]}`,
 		`[{"op": "copy", "path": "/foo/0", "from": "/foo"}]`,
 		`{ "foo": [["bar"], "bar"]}`,
+	},
+	{
+		`{ "foo": null}`,
+		`[{"op": "copy", "path": "/bar", "from": "/foo"}]`,
+		`{ "foo": null, "bar": null}`,
 	},
 	{
 		`{ "foo": ["bar","qux","baz"]}`,
@@ -292,6 +327,10 @@ var BadCases = []BadCase{
 	},
 	{
 		`{ "foo": []}`,
+		`[ {"op": "remove", "path": "/foo/-", "value": "asd"}]`,
+	},
+	{
+		`{ "foo": []}`,
 		`[ {"op": "remove", "path": "/foo/-1"}]`,
 	},
 	{
@@ -331,6 +370,15 @@ var BadCases = []BadCase{
 	{
 		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,
 		`[ { "op": "move", "from": "/foo/1", "path": "/foo/4" } ]`,
+	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "replace", "path": "/foo", "value": "bar" } ]`,
+	},
+	// Can't copy from non-existent "from" key.
+	{
+		`{ "foo": "bar"}`,
+		`[{"op": "copy", "path": "/qux", "from": "/baz"}]`,
 	},
 }
 
@@ -458,6 +506,18 @@ var TestCases = []TestCase{
 		`[ { "op": "test", "path": "/foo"} ]`,
 		false,
 		"/foo",
+	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "test", "path": "/baz", "value": "bar" } ]`,
+		false,
+		"/baz",
+	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "test", "path": "/baz", "value": null } ]`,
+		true,
+		"/baz",
 	},
 }
 


### PR DESCRIPTION
Add support for delete by value. This changeset borrows the changes from https://github.com/evanphx/json-patch/pull/103/files and also adds support for deletion by partial value in cases when the value in the array is an object.